### PR TITLE
fix:'capacitor-swift-pm' 7.4.2 and 'file-transfer' depends on 'capacitor-swift-pm' 7.1.0.

### DIFF
--- a/packages/capacitor-plugin/Package.swift
+++ b/packages/capacitor-plugin/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["FileTransferPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "7.1.0")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .binaryTarget(


### PR DESCRIPTION
```
✔ Please choose a target device: › iPhone 16 (simulator) (63296FAA-9341-48CC-8B03-F7C6BDB030FD)
✖ Running xcodebuild - failed!
[error] Command line invocation:
        /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project App.xcodeproj -scheme App -configuration
        Debug -destination id=63296FAA-9341-48CC-8B03-F7C6BDB030FD -derivedDataPath
        /Users/never/Documents/workSpace/lllix/lllix-app/ios/DerivedData/63296FAA-9341-48CC-8B03-F7C6BDB030FD
        
        Resolve Package Graph
        
        2025-07-24 21:29:36.516 xcodebuild[58230:202354876] Writing error result bundle to
        /var/folders/k5/6x_nn7hj305b06yr74ftptt00000gn/T/ResultBundle_2025-24-07_21-29-0036.xcresult
        xcodebuild: error: Could not resolve package dependencies:
        Failed to resolve dependencies Dependencies could not be resolved because 'capapp-spm' depends on
        'capacitor-swift-pm' 7.4.2 and 'file-transfer' depends on 'capacitor-swift-pm' 7.1.0.
```