### PR TITLE
fix(android): upload with content URIs

### DIFF
--- a/packages/capacitor-plugin/android/build.gradle
+++ b/packages/capacitor-plugin/android/build.gradle
@@ -58,7 +58,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.aar', '*.jar'])
     implementation project(':capacitor-android')
-    implementation "io.ionic.libs:ionfiletransfer-android:1.0.0"
+    implementation "io.ionic.libs:ionfiletransfer-android:1.0.1"
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
 
     testImplementation "junit:junit:$junitVersion"

--- a/packages/example-app/src/js/file-transfer-app.js
+++ b/packages/example-app/src/js/file-transfer-app.js
@@ -336,30 +336,7 @@ window.customElements.define(
         const uploadProgressContainer = this.shadowRoot.querySelector('#uploadProgressContainer');
         uploadProgressContainer.style.display = uploadProgress.checked ? 'block' : 'none';
 
-        let filePath;
-        
-        if (Capacitor.getPlatform() === 'web') {
-          filePath = file.name;
-        } else {
-            const base64 = await new Promise((resolve, reject) => {
-              const reader = new FileReader();
-              reader.onload = () => {
-                const result = reader.result;
-                resolve(result.split(',')[1]);
-              };
-              reader.onerror = reject;
-              reader.readAsDataURL(file);
-            });
-          
-            const savedFile = await Filesystem.writeFile({
-              path: file.name,
-              data: base64,
-              directory: Directory.Cache,
-            });
-
-            filePath = await savedFile.uri;
-        }
-
+        let filePath = file.name;
         // Upload file
         const result = await FileTransfer.uploadFile({
           url,


### PR DESCRIPTION
Addresses https://github.com/ionic-team/capacitor-file-transfer/issues/9 

The fix was done in https://github.com/ionic-team/ion-android-filetransfer/pull/9 - This PR updates the native library version

Also removed some logic in the example app to handle the file upload, because it is working in Android and iOS without it - I believe at the time we added it because we were having some issues on Android, but we thought it just an issue with the web file selector, when it fact it was an issue in the plugin.