### PR TITLE
chore(cicd): Fix release github action

### DIFF
--- a/.github/workflows/release_plugin.yml
+++ b/.github/workflows/release_plugin.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - development
       - next
-      - main
   workflow_dispatch:
 
 permissions:

--- a/packages/capacitor-plugin/release.config.cjs
+++ b/packages/capacitor-plugin/release.config.cjs
@@ -2,7 +2,7 @@ module.exports = {
   branches: [
     { name: 'main', channel: 'latest' },
     { name: 'next', channel: 'next', prerelease: true },
-    { name: 'dev', channel: 'dev', prerelease: true },
+    { name: 'development', channel: 'dev', prerelease: true },
   ],
   repositoryUrl: 'https://github.com/ionic-team/capacitor-file-transfer.git',
   plugins: [


### PR DESCRIPTION
Update release GitHub action in the following ways:

- Correct branch name for dev tag releases.
- Not run automatically on push to main. The reason I changed this is because this way we can choose when to release a stable, in case we want to bundle multiple features / fixes. Releases are still running automatically for non-stable branches.