### PR TITLE
fix(ios): Simplify SPM usage for native library

### DIFF
--- a/.github/actions/prepare-example-app/action.yml
+++ b/.github/actions/prepare-example-app/action.yml
@@ -1,0 +1,22 @@
+name: 'Prepare Example app'
+description: 'Does necessary pre-work for the example app to compile natively'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Build plugin'
+      working-directory: ./packages/capacitor-plugin
+      shell: bash
+      run: npm run build
+    - name: 'Install example app dependencies'
+      working-directory: ./packages/example-app
+      shell: bash
+      run: npm i
+    - name: 'Build Web example app'
+      working-directory: ./packages/example-app
+      shell: bash
+      run: npm run build
+    - name: 'Sync example app native platforms'
+      working-directory: ./packages/example-app
+      shell: bash
+      run: npx cap sync

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -16,41 +16,54 @@ jobs:
     needs: 'setup'
     uses: ./.github/workflows/reusable_build.yml
 
-  verify-plugin:
+  verify-plugin-android:
     needs: ['setup', 'lint', 'build']
-    runs-on: 'macos-14'
+    runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
-      - name: 'Verify iOS + Android + Web'
+      - name: 'Verify Android'
         working-directory: ./packages/capacitor-plugin
-        run: npm run verify
+        run: npm run verify:android
 
-  build-example-app:
-    needs: ['verify-plugin']
-    runs-on: 'macos-14'
+  verify-plugin-ios:
+    needs: ['setup', 'lint', 'build']
+    runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
-      - name: 'Build plugin'
+      - name: 'Verify iOS'
         working-directory: ./packages/capacitor-plugin
-        run: npm run build
-      - name: 'Install example app dependencies'
-        working-directory: ./packages/example-app
-        run: npm i
-      - name: 'Build Web example app'
-        working-directory: ./packages/example-app
-        run: npm run build
-      - name: 'Sync example app native platforms'
-        working-directory: ./packages/example-app
-        run: npx cap sync
+        run: npm run verify:ios
+
+  build-example-app-android:
+    needs: ['verify-plugin-ios', 'verify-plugin-android']
+    runs-on: 'macos-15'
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Setup Tools'
+        uses: ./.github/actions/setup-tools
+      - name: 'Prepare example app'
+        uses: ./.github/actions/prepare-example-app
       - name: 'Build Android example app'
         working-directory: ./packages/example-app/android
         run: ./gradlew clean assembleDebug
+    
+  build-example-app-ios:
+    needs: ['verify-plugin-ios', 'verify-plugin-android']
+    runs-on: 'macos-15'
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Setup Tools'
+        uses: ./.github/actions/setup-tools
+      - name: 'Prepare example app'
+        uses: ./.github/actions/prepare-example-app
       - name: 'Build iOS example app'
         working-directory: ./packages/example-app/ios/App
         run: xcodebuild clean build -workspace App.xcworkspace -scheme App CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/packages/capacitor-plugin/Package.swift
+++ b/packages/capacitor-plugin/Package.swift
@@ -11,20 +11,16 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0"),
+        .package(url: "https://github.com/ionic-team/ion-ios-filetransfer.git", from: "1.0.1")
     ],
     targets: [
-        .binaryTarget(
-            name: "IONFileTransferLib",
-            url: "https://github.com/ionic-team/ion-ios-filetransfer/releases/download/1.0.1/IONFileTransferLib.zip",
-            checksum: "0a239f814fa3746f68850246855d974c9795f60342897413212b2b46690f70d5" // sha-256
-        ),
         .target(
             name: "FileTransferPlugin",
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
-                "IONFileTransferLib"
+                .product(name: "IONFileTransferLib", package: "ion-ios-filetransfer")
             ],
             path: "ios/Sources/FileTransferPlugin"),
         .testTarget(


### PR DESCRIPTION
This PR updates the SPM declaration of the iOS FileViewer native library to be retrieved from GitHub directly instead of relying on a binary target.