### PR TITLE
fix(web): Check the existence of the folder before mkdir.

### DIFF
--- a/packages/capacitor-plugin/src/web.ts
+++ b/packages/capacitor-plugin/src/web.ts
@@ -12,6 +12,7 @@ import type {
 // Type definitions for the Capacitor Filesystem API
 interface FilesystemPlugin {
   readFile(options: { path: string }): Promise<{ data: string }>;
+  stat(options: { path: string }): Promise<{ data: string }>;
   writeFile(options: {
     path: string;
     data: string;
@@ -469,9 +470,11 @@ export class FileTransferWeb extends WebPlugin implements FileTransferPlugin {
       const pathParts = path.split("/");
       if (pathParts.length > 1) {
         const directory = pathParts.slice(0, -1).join("/");
-        await filesystem.mkdir({
-          path: directory,
-          recursive: true,
+        await filesystem.stat({path: directory}).catch(async ()=>{
+          await filesystem.mkdir({
+           path: directory,
+           recursive: true,
+          });
         });
       }
 


### PR DESCRIPTION
[capacitor-filesystem](https://github.com/ionic-team/capacitor-filesystem/blob/6d5fe9b564de8fa26e6308533ac52b3523b5b9d3/packages/capacitor-plugin/src/web.ts#L296) throws error on mkdir when directory already exists
so we need a check before mkdir

otherwise, like this demo

```
const src = 'http://127.0.0.1:8080/a.mp4';
const tgt = 'video/sample.mp4';

  const fileInfo = await Filesystem.getUri({
    directory: Directory.Documents,
    path: tgt,
  });

  await FileTransfer.downloadFile({
    url: src,
    path: fileInfo.uri,
    progress: true
  });
```
first time boot, ok
second time, will throw error