### PR TITLE
Fix web implementation by removing directory creation

### DIFF
--- a/packages/capacitor-plugin/src/web.ts
+++ b/packages/capacitor-plugin/src/web.ts
@@ -17,7 +17,6 @@ interface FilesystemPlugin {
     data: string;
     recursive?: boolean;
   }): Promise<void>;
-  mkdir(options: { path: string; recursive?: boolean }): Promise<void>;
 }
 
 // Extend Window interface to include Capacitor
@@ -463,16 +462,6 @@ export class FileTransferWeb extends WebPlugin implements FileTransferPlugin {
       const base64Data = await this.blobToBase64(blob);
       if (!base64Data) {
         throw new Error("Failed to convert blob to base64");
-      }
-
-      // Create any parent directories needed
-      const pathParts = path.split("/");
-      if (pathParts.length > 1) {
-        const directory = pathParts.slice(0, -1).join("/");
-        await filesystem.mkdir({
-          path: directory,
-          recursive: true,
-        });
       }
 
       // Write the file


### PR DESCRIPTION

Hi :wave:

This PR addresses a bug in the web implementation where the logic for creating parent directories before writing a downloaded file fails.

Since the web `Filesystem` uses IndexedDB a **key/value** store (key: filepath, value: file content and metadata) it does not support the concept of "directories" in the traditional filesystem sense.

Attempting to create directories in this context is not only unnecessary but also causes errors.
