### PR TITLE
fix(android): Correctly returning headers for upload

### DIFF
--- a/packages/capacitor-plugin/android/src/main/java/com/capacitorjs/plugins/filetransfer/FileTransferPlugin.kt
+++ b/packages/capacitor-plugin/android/src/main/java/com/capacitorjs/plugins/filetransfer/FileTransferPlugin.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.media.MediaScannerConnection
 import android.os.Build
 import android.os.Environment
+import androidx.core.net.toUri
 import com.getcapacitor.JSObject
 import com.getcapacitor.PermissionState
 import com.getcapacitor.Plugin
@@ -25,7 +26,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import androidx.core.net.toUri
 
 @CapacitorPlugin(
     name = "FileTransfer",
@@ -252,12 +252,18 @@ class FileTransferPlugin : Plugin() {
                             )
                             notifyProgress("upload", url, finalStatus, forceUpdate = true)
                         }
-                        
+
+                        val headersObj = JSObject()
+                        result.data.headers?.entries?.forEach { (key, values) ->
+                            key?.let { headerKey ->
+                                headersObj.put(headerKey, values.firstOrNull() ?: "")
+                            }
+                        }
                         val response = JSObject().apply {
                             put("bytesSent", result.data.totalBytes)
                             put("responseCode", result.data.responseCode)
                             put("response", result.data.responseBody)
-                            put("headers", result.data.headers)
+                            put("headers", headersObj)
                         }
                         call.resolve(response)
                     }


### PR DESCRIPTION
This was something that exists in the [Cordova version of this plugin](https://github.com/ionic-team/cordova-outsystems-file-transfer/blob/917504fd3211faf17ae72515a0ab26c588484f27/packages/cordova-plugin/android/OSFileTransferPlugin.kt#L248), but seems to be missing from the Capacitor version.

#### Before fix

<img width="240" alt="image" src="https://github.com/user-attachments/assets/022c4ad5-4ae8-4bfc-b55e-ede283dd6061" />

#### After fix from this PR

<img width="240" alt="image" src="https://github.com/user-attachments/assets/2e743247-6f97-4ae7-b6f1-d3ec1a50b7ab" />
