### PR TITLE
fix(ios): Send upload response code as string instead of number

### DIFF
--- a/packages/capacitor-plugin/ios/Sources/FileTransferPlugin/FileTransferPlugin.swift
+++ b/packages/capacitor-plugin/ios/Sources/FileTransferPlugin/FileTransferPlugin.swift
@@ -229,7 +229,7 @@ public class FileTransferPlugin: CAPPlugin, CAPBridgedPlugin {
                     case .upload:
                         return [
                             "bytesSent": data.totalBytes,
-                            "responseCode": data.responseCode,
+                            "responseCode": "\(data.responseCode)",
                             "response": data.responseBody ?? "",
                             "headers": data.headers.reduce(into: JSObject()) { result, entry in
                                 result[entry.key] = entry.value


### PR DESCRIPTION
Addresses https://github.com/ionic-team/capacitor-file-transfer/issues/32

In truth, this Plugin's API could have a number instead of string for `UploadFileResult#responseCode`, as we have for `FileTransferError#httpStatus`, but changing this now would be a breaking change, so this PR limits itself to just fixing iOS.