### PR TITLE
[BUG] v1.0.8 Android build fails: plugin pins AGP 8.7.3 which cannot be resolved from Google Maven #52

### DIFF
--- a/packages/capacitor-plugin/android/build.gradle
+++ b/packages/capacitor-plugin/android/build.gradle
@@ -12,7 +12,6 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
Changes:
- do NOT pin AGP as it must be controlled by the root project (for v1.x)