### PR TITLE
fix: Align HTTP error message

### DIFF
--- a/packages/capacitor-plugin/android/src/main/java/com/capacitorjs/plugins/filetransfer/FileTransferErrors.kt
+++ b/packages/capacitor-plugin/android/src/main/java/com/capacitorjs/plugins/filetransfer/FileTransferErrors.kt
@@ -81,7 +81,7 @@ object FileTransferErrors {
     
     fun httpError(responseCode: String, message: String, responseBody: String?, headers: Map<String, List<String>>?) = ErrorInfo(
         code = formatErrorCode(10),
-        message = "HTTP error: $responseCode - $message",
+        message = message,
         httpStatus = responseCode.toIntOrNull(),
         body = responseBody,
         headers = headers,

--- a/packages/capacitor-plugin/ios/Sources/FileTransferPlugin/FileTransferErrors.swift
+++ b/packages/capacitor-plugin/ios/Sources/FileTransferPlugin/FileTransferErrors.swift
@@ -129,7 +129,7 @@ extension FileTransferError {
     ) -> FileTransferError {
         .init(
             code: 10,
-            message: "HTTP error: \(responseCode) - \(message)",
+            message: message,
             httpStatus: responseCode,
             body: responseBody,
             headers: headers,

--- a/packages/capacitor-plugin/src/web.ts
+++ b/packages/capacitor-plugin/src/web.ts
@@ -63,7 +63,7 @@ export class FileTransferWeb extends WebPlugin implements FileTransferPlugin {
         });
 
         if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
+          throw new Error(`HTTP error: ${response.status}`);
         }
 
         // Handle progress reporting during download if needed
@@ -233,7 +233,7 @@ export class FileTransferWeb extends WebPlugin implements FileTransferPlugin {
               headers,
             });
           } else {
-            reject(new Error(`HTTP error! status: ${xhr.status}`));
+            reject(new Error(`HTTP error: ${xhr.status}`));
           }
         };
 


### PR DESCRIPTION
When reviewing the File Transfer plugin errors, I'm noticing that when an HTTP error occur, we are returning a duplicate error message. "HTTP Error: 400 - Http Error: 400". So this PR aligns that error message between platforms to just be "HTTP error: 400".

I'll be opening other PRs in the near future to address other issues / limitations in our plugin's error handling, but this one is the first (and simplest one).