### PR TITLE
fix(ios): http body in error and send progress only when success

### DIFF
--- a/packages/capacitor-plugin/CapacitorFileTransfer.podspec
+++ b/packages/capacitor-plugin/CapacitorFileTransfer.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
   s.source_files = 'ios/Sources/FileTransferPlugin/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
-  s.dependency 'IONFileTransferLib', spec='~> 1.0.1'
+  s.dependency 'IONFileTransferLib', spec='~> 1.0.2'
   s.dependency 'Capacitor'
   s.swift_version = '5.1'
 end

--- a/packages/capacitor-plugin/Package.swift
+++ b/packages/capacitor-plugin/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
-        .package(url: "https://github.com/ionic-team/ion-ios-filetransfer.git", from: "1.0.1")
+        .package(url: "https://github.com/ionic-team/ion-ios-filetransfer.git", from: "1.0.2")
     ],
     targets: [
         .target(

--- a/packages/example-app/src/js/file-transfer-app.js
+++ b/packages/example-app/src/js/file-transfer-app.js
@@ -102,6 +102,7 @@ window.customElements.define(
                 <option value="">Select a file to download</option>
                 <option value="https://raw.githubusercontent.com/mozilla/pdf.js/ba2edeae/examples/learning/helloworld.pdf">Small PDF (~1KB)</option>
                 <option value="https://raw.githubusercontent.com/kyokidG/large-pdf-viewer-poc/58a3df6adc4fe9bd5f02d2f583d6747e187d93ae/public/test2.pdf">Large PDF (~20MB)</option>
+                <option value="https://raw.githubusercontent.com/mozilla/pdf.js/ba2edeae/examples/learning/invalid.pdf">Non-existent file (HTTP 404)</option>
               </select>
               <input type="url" id="customDownloadUrl" placeholder="Or enter custom URL">
             </div>
@@ -141,6 +142,7 @@ window.customElements.define(
               <select id="uploadUrl" class="url-select">
                 <option value="">Select an upload endpoint</option>
                 <option value="https://httpbin.org/post">HTTPBin (Test File Upload)</option>
+                <option value="https://api.github.com/repos/octocat/Spoon-Knife/issues">Non-Upload URL (HTTP error)</option>
               </select>
               <input type="url" id="customUploadUrl" placeholder="Or enter custom URL">
             </div>

--- a/packages/example-app/src/js/file-transfer-app.js
+++ b/packages/example-app/src/js/file-transfer-app.js
@@ -251,7 +251,7 @@ window.customElements.define(
           });
         }
       } catch (error) {
-        this.showError('Directory initialization error: ' + error.message);
+        this.showError('Directory initialization error: ' + error.code + " -> " + error.message);
       }
     }
 
@@ -322,7 +322,7 @@ window.customElements.define(
 
         this.showResponse('Download completed', result);
       } catch (error) {
-        this.showError('Download failed: ' + error.message);
+        this.showError('Download failed: ' + JSON.stringify(error, null, 2));
       }
     }
 


### PR DESCRIPTION
Final PR to address https://github.com/ionic-team/capacitor-file-transfer/issues/18 - iOS was not returning the http body in the error object when an http error occured. Furthermore, I saw that iOS was notifying download progress when an HTTP error occurred, which is incorrect.

Both these fixes come from the iOS native library consumed by this plugin, implementation in https://github.com/ionic-team/ion-ios-filetransfer/pull/13.

This PR also adds a few more options to the example app to be able to receive HTTP errors.