### PR TITLE
chore(android): upgrade to gradle 9

### DIFF
--- a/packages/capacitor-plugin/android/build.gradle
+++ b/packages/capacitor-plugin/android/build.gradle
@@ -12,13 +12,12 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.0'
+        classpath 'com.android.tools.build:gradle:9.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     namespace = "com.capacitorjs.plugins.filetransfer"
@@ -62,7 +61,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
 
     testImplementation "junit:junit:$junitVersion"
-    
+
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
 }

--- a/packages/capacitor-plugin/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/capacitor-plugin/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/example-app/android/app/build.gradle
+++ b/packages/example-app/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/packages/example-app/android/build.gradle
+++ b/packages/example-app/android/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    
+
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.0'
+        classpath 'com.android.tools.build:gradle:9.0.1'
         classpath 'com.google.gms:google-services:4.4.4'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/packages/example-app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/example-app/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This upgrades this plugin to gradle 9 for android. Using it in gradle 9 projects currently fails due to the kotlin plugin being applied twice (by the root project and the plugin):
> Cannot add extension with name 'kotlin', as there is an extension already registered with that name.

The example app does not compile on android due to the same issue with the https://github.com/ionic-team/capacitor-file-viewer and https://github.com/ionic-team/capacitor-filesystem plugins. Should I file corresponding PRs there too?