### PR TITLE
fix(ios): update dependency to IONFileTransferLib to version built with Xcode 16

### DIFF
--- a/packages/capacitor-plugin/CapacitorFileTransfer.podspec
+++ b/packages/capacitor-plugin/CapacitorFileTransfer.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
   s.source_files = 'ios/Sources/FileTransferPlugin/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '14.0'
-  s.dependency 'IONFileTransferLib', spec='~> 1.0.2'
+  s.dependency 'IONFileTransferLib', spec='~> 1.0.3'
   s.dependency 'Capacitor'
   s.swift_version = '5.1'
 end

--- a/packages/capacitor-plugin/Package.swift
+++ b/packages/capacitor-plugin/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0"),
-        .package(url: "https://github.com/ionic-team/ion-ios-filetransfer.git", from: "1.0.2")
+        .package(url: "https://github.com/ionic-team/ion-ios-filetransfer.git", from: "1.0.3")
     ],
     targets: [
         .target(

--- a/packages/example-app/ios/App/Podfile.lock
+++ b/packages/example-app/ios/App/Podfile.lock
@@ -5,14 +5,14 @@ PODS:
   - CapacitorFilesystem (7.1.3):
     - Capacitor
     - IONFilesystemLib (~> 1.0)
-  - CapacitorFileTransfer (1.0.4):
+  - CapacitorFileTransfer (1.0.11):
     - Capacitor
-    - IONFileTransferLib (~> 1.0.1)
+    - IONFileTransferLib (~> 1.0.3)
   - CapacitorFileViewer (1.0.2):
     - Capacitor
     - IONFileViewerLib (~> 1.0.1)
   - IONFilesystemLib (1.0.1)
-  - IONFileTransferLib (1.0.1)
+  - IONFileTransferLib (1.0.3)
   - IONFileViewerLib (1.0.1)
 
 DEPENDENCIES:
@@ -41,13 +41,13 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/file-viewer"
 
 SPEC CHECKSUMS:
-  Capacitor: fcbee427ff437f414bbb3bc2d39364ad9bd2b8a5
+  Capacitor: 82d1f3b4480d66b5996814f74500dcbc0908558c
   CapacitorCordova: 345f93b7edd121db98e4ec20ac94d6d7bcaf7e48
-  CapacitorFilesystem: 8e48bb1a036caf0d01605eb4bfe74b880cca8f80
-  CapacitorFileTransfer: 776bdbc7d71a490a79c81ea97bf25f069c632106
-  CapacitorFileViewer: 4f6fcd47151b904e2d7cf57ebd7dd3739c10da9e
+  CapacitorFilesystem: 0329ace667c6b971410cab3619dfb98a39cc3b86
+  CapacitorFileTransfer: 2981b9fe1b57a1b013ae70544947a0f99cecde5b
+  CapacitorFileViewer: 47cf03d7cb5a313cbc1209baa83da2edc6f650be
   IONFilesystemLib: 89258b8e3e85465da93127d25d7ce37f977e8a6f
-  IONFileTransferLib: b268561ab0ba7f386eea228c4986b55ba0146ca9
+  IONFileTransferLib: addbbf50405c163dcd74a7b1bd8c6f9302342be2
   IONFileViewerLib: 9e6b09451afa7705545d4d20e2974b4f1555390c
 
 PODFILE CHECKSUM: 76668ea156e59ff21841d22849461df8faf9b06b


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Capacitor 7 targets Xcode 16 and not 26

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation

## Rationale / Problems Fixed
<!--- Give us more information about why you think this PR is needed, or what problems it fixes -->
<!--- Be sure to place links to related issues or discussions here -->

Capacitor 7 targets Xcode 16 and not 26. The previous version of the library (1.0.2) was built with Xcode 26 and this could lead to build problems.

## Tests or Reproductions
<!--- Include a link to a minimal test project that can be used to validate the changes -->
<!--- Alternatively, describe how you tested your changes in detail -->
<!--- The easier it is to test and validate your pull request, the faster it can be reviewed -->

## Screenshots / Media
<!--- (Optional) Include screenshots, videos or other files relevant to the pull request -->

## Platforms Affected
- [ ] Android
- [x] iOS
- [ ] Web

## Notes / Comments
<!--- Put anything else here that would be good for us to know! -->
