### PR TITLE
ci: update node to 24 and update action versions

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -7,11 +7,7 @@ runs:
     - name: Install Node.js
       uses: actions/setup-node@v7
       with:
-        node-version: 24 # semantic-release requires at least this version, or 22 LTS
-    # Ensure npm 11.5.1 or later is installed for Trusted publishing
-    - name: Update npm
-      shell: bash
-      run: npm install -g npm@~11.10.0
+        node-version: 24
     - name: Install dependencies
       working-directory: ./packages/capacitor-plugin
       shell: bash

--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -5,7 +5,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24 # semantic-release requires at least this version, or 22 LTS
     # Ensure npm 11.5.1 or later is installed for Trusted publishing

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
       - name: 'Verify Android'
@@ -33,7 +33,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
       - name: 'Verify iOS'
@@ -45,7 +45,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
       - name: 'Prepare example app'
@@ -59,7 +59,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
       - name: 'Prepare example app'

--- a/.github/workflows/release_plugin.yml
+++ b/.github/workflows/release_plugin.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.THE_GH_RELEASE_TOKEN || github.token }}

--- a/.github/workflows/reusable_lint.yml
+++ b/.github/workflows/reusable_lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.THE_GH_RELEASE_TOKEN || github.token }}
 

--- a/.github/workflows/reusable_setup.yml
+++ b/.github/workflows/reusable_setup.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.THE_GH_RELEASE_TOKEN || github.token }}
 


### PR DESCRIPTION
Equivalent PR to ionic-team/capacitor#8557

Updates to macos runner and Xcode version are out-of-scope, to be done in other task / PR.

Internal JIRA Ref: https://outsystemsrd.atlassian.net/browse/RMET-4731